### PR TITLE
SCALRCORE-36689 Bump python and cli-tools to latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PIP_ROOT_USER_ACTION=ignore
 RUN <<EOT
   # See: https://gregoryszorc.com/docs/python-build-standalone/main/running.html#extracting-distributions
   export VERSION="${PYTHON_VERSION}"
-  export RELEASE="20250517"
+  export RELEASE="20251209"
   apt-get update -y
   apt-get install -y --no-install-recommends zstd binutils
   [ "${TARGETARCH}" = "amd64" ] && export OPTIONS="x86_64-unknown-linux-gnu-pgo+lto-full"

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,14 +49,14 @@ RUN <<EOT
   rm python.tar.zst
   rm -rf python
   # Strip debug symbols from shared libraries.
-  strip -d /usr/lib/libpython3.13.so
+  strip -d /usr/lib/libpython3.14.so
   # Remove unneeded packages.
   rm -rf /usr/lib/Tix* /usr/lib/tcl* /usr/lib/tk* /usr/lib/itcl* /usr/lib/thread*
-  rm -rf /usr/lib/libpython3.13.a
-  rm -rf "/usr/lib/python3.13/config-3.13-$(uname -m)-linux-gnu"
-  rm -rf /usr/lib/python3.13/ensurepip
-  rm -rf /usr/lib/python3.13/tkinker
-  rm -rf /usr/lib/python3.13/test
+  rm -rf /usr/lib/libpython3.14.a
+  rm -rf "/usr/lib/python3.14/config-3.14-$(uname -m)-linux-gnu"
+  rm -rf /usr/lib/python3.14/ensurepip
+  rm -rf /usr/lib/python3.14/tkinker
+  rm -rf /usr/lib/python3.14/test
   # Cleanup.
   apt-get remove -y zstd binutils
   apt-get clean

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This environment comes pre-equipped with a comprehensive suite of tools essentia
   * wget - File downloads from the web
   * ca-certificates - Trusted CA certificates
 * **Programming Languages**
-  * Python ([v3.13.3](https://www.python.org/downloads/release/python-3133/)) - General-purpose programming language (release)
+  * Python ([v3.14.2](https://www.python.org/downloads/release/python-3142/)) - General-purpose programming language (release)
   * jq - Command-line JSON processor
 * **Cloud Clients**
   * AWS CLI ([2.27.1](https://github.com/aws/aws-cli/releases/tag/2.27.32)) - Amazon Web Services CLI.
@@ -42,12 +42,12 @@ The environment uses the [standalone Python build](https://github.com/astral-sh/
 
 ```bash
 docker buildx build \
-  --build-arg PYTHON_VERSION=3.13.3 \
-  --build-arg KUBECTL_VERSION=v1.33.1 \
-  --build-arg GCLOUD_VERSION=525.0.0 \
-  --build-arg AWS_CLI_VERSION=2.27.1 \
-  --build-arg AZURE_CLI_VERSION=2.71.0 \
-  --build-arg SCALR_CLI_VERSION=0.17.1 \
+  --build-arg PYTHON_VERSION=3.14.2 \
+  --build-arg KUBECTL_VERSION=v1.34.3 \
+  --build-arg GCLOUD_VERSION=549.0.0 \
+  --build-arg AWS_CLI_VERSION=2.32.13 \
+  --build-arg AZURE_CLI_VERSION=2.81.0 \
+  --build-arg SCALR_CLI_VERSION=0.17.4 \
   --platform linux/amd64 \
   -t scalr/runner:latest --load .
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Two Python variants are available:
 ```bash
 docker buildx build \
   --build-arg PYTHON_VERSION=3.14.4 \
-  --build-arg PYTHON_RELEASE=20260114 \
+  --build-arg PYTHON_RELEASE=20260408 \
   --build-arg KUBECTL_VERSION=v1.35.3 \
   --build-arg GCLOUD_VERSION=564.0.0 \
   --build-arg AWS_CLI_VERSION=2.34.29 \
@@ -64,7 +64,7 @@ To build the Python 3.9 variant:
 
 ```bash
 docker buildx build \
-  --build-arg PYTHON_VERSION=3.14.4 \
+  --build-arg PYTHON_VERSION=3.9.25 \
   --build-arg PYTHON_RELEASE=20251031 \
   --build-arg KUBECTL_VERSION=v1.35.3 \
   --build-arg GCLOUD_VERSION=564.0.0 \

--- a/versions
+++ b/versions
@@ -1,6 +1,6 @@
-kubectl=v1.33.1
-gcloud=525.0.0
-aws_cli=2.27.32
-azure_cli=2.74.0
-scalr_cli=0.17.1
-python=3.13.3
+kubectl=v1.34.3
+gcloud=549.0.0
+aws_cli=2.32.13
+azure_cli=2.81.0
+scalr_cli=0.17.4
+python=3.14.2


### PR DESCRIPTION
Changes:
- **Updated python: 3.13.3 → 3.14.4 (minor release)**
- Updated CLI tools and runtime environments to the latest stable releases:
  - kubectl: v1.35.0 -> v1.35.3
  - gcloud: 552.0.0 -> 564.0.0
  - aws_cli: 2.33.2 -> 2.34.29
  - azure_cli: 2.82.0 -> 2.85.0
  - scalr_cli: 0.17.6 -> 0.17.8
